### PR TITLE
add rockspec file for packaging lua bindings

### DIFF
--- a/lua/astal-dev-1.rockspec
+++ b/lua/astal-dev-1.rockspec
@@ -1,0 +1,22 @@
+package = "astal"
+version = "dev-1"
+source = {
+   url = "git+https://github.com/astal-sh/libastal"
+}
+description = {
+   summary = "lua bindings for libastal.",
+   homepage = "https://github.com/astal-sh/libastal",
+   license = "GPL-3"
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["astal.application"] = "astal/application.lua",
+      ["astal.binding"] = "astal/binding.lua",
+      ["astal.init"] = "astal/init.lua",
+      ["astal.process"] = "astal/process.lua",
+      ["astal.time"] = "astal/time.lua",
+      ["astal.variable"] = "astal/variable.lua",
+      ["astal.widget"] = "astal/widget.lua",
+  }
+}


### PR DESCRIPTION
This PR adds a rockspec file, so the lua bindings can be packaged using luarocks.