### PR TITLE
add g_icon property to icon widget

### DIFF
--- a/src/widget/icon.vala
+++ b/src/widget/icon.vala
@@ -10,6 +10,7 @@ public class Icon : Gtk.Image {
 
     public new Gdk.Pixbuf pixbuf { get; set; }
     public string icon { get; set; default = ""; }
+    public GLib.Icon g_icon {get; set;}
 
     private async void display_icon() {
         switch(type) {
@@ -45,6 +46,11 @@ public class Icon : Gtk.Image {
                 set_from_surface(cs);
             }
             break;
+        case IconType.GICON:
+            pixel_size = (int)size;
+            gicon = g_icon;
+            break;
+
         }
     }
 
@@ -71,6 +77,11 @@ public class Icon : Gtk.Image {
             display_icon.begin();
         });
 
+        notify["g-icon"].connect(() => {
+            type = IconType.GICON;
+            display_icon.begin();
+        });
+        
         size_allocate.connect(() => {
             size = get_style_context()
                 .get_property("font-size", Gtk.StateFlags.NORMAL).get_double();
@@ -91,5 +102,6 @@ private enum IconType {
     NAMED,
     FILE,
     PIXBUF,
+    GICON,
 }
 }


### PR DESCRIPTION
adds a g_icon property to the icon widget. This allows for easier icon management, especially in combination with the Tray service. Currently the user had to check whether a tray item has a pixbuf, or a named icon and then set the pixbuf or icon property of the icon widget. 
This pr adds a g_icon property and now allows something like this:
```js
<icon g_icon={bind(item, "gicon")>
```